### PR TITLE
4615cab2c7dd41c5740325659ccb40374eef6dc3 j2cl-java-util-Locale 20200418

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 
         <dependency>
             <groupId>walkingkooka</groupId>
-            <artifactId>java-util-Locale-j2cl</artifactId>
+            <artifactId>j2cl-java-util-Locale</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>

--- a/src/test/java/walkingkooka/j2cl/java/text/DateFormatSymbolsTest.java
+++ b/src/test/java/walkingkooka/j2cl/java/text/DateFormatSymbolsTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.set.Sets;
-import walkingkooka.javautillocalej2cl.WalkingkookaLocale;
+import walkingkooka.j2cl.WalkingkookaLanguageTag;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
 
@@ -115,7 +115,7 @@ public final class DateFormatSymbolsTest implements ClassTesting<DateFormatSymbo
     @Test
     public void testGetInstanceLocaleAllLocales() {
         for (final Locale locale : Locale.getAvailableLocales()) {
-            if(WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if(WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.check(DateFormatSymbols.getInstance(locale), java.text.DateFormatSymbols.getInstance(locale));
@@ -154,7 +154,7 @@ public final class DateFormatSymbolsTest implements ClassTesting<DateFormatSymbo
     @Test
     public void testNewLocaleAllLocales() {
         for (final Locale locale : Locale.getAvailableLocales()) {
-            if(WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if(WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.check(new DateFormatSymbols(locale), new java.text.DateFormatSymbols(locale));
@@ -186,7 +186,7 @@ public final class DateFormatSymbolsTest implements ClassTesting<DateFormatSymbo
     @Test
     public void testCloneState2() {
         for (final Locale locale : Locale.getAvailableLocales()) {
-            if(WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if(WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             final DateFormatSymbols symbols = new DateFormatSymbols(locale);

--- a/src/test/java/walkingkooka/j2cl/java/text/DecimalFormatSymbolsTest.java
+++ b/src/test/java/walkingkooka/j2cl/java/text/DecimalFormatSymbolsTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.set.Sets;
-import walkingkooka.javautillocalej2cl.WalkingkookaLocale;
+import walkingkooka.j2cl.WalkingkookaLanguageTag;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
 
@@ -127,7 +127,7 @@ public final class DecimalFormatSymbolsTest implements ClassTesting<DecimalForma
     @Test
     public void testGetInstanceLocaleAllLocales() {
         for (final Locale locale : Locale.getAvailableLocales()) {
-            if(WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if(WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.check(DecimalFormatSymbols.getInstance(locale),
@@ -198,7 +198,7 @@ public final class DecimalFormatSymbolsTest implements ClassTesting<DecimalForma
     @Test
     public void testCurrencyAllLocales() {
         for (final Locale locale : java.text.DecimalFormatSymbols.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.getCurrencyAndCheck(locale);
@@ -257,7 +257,7 @@ public final class DecimalFormatSymbolsTest implements ClassTesting<DecimalForma
     @Test
     public void testSetCurrencyAllLocalesAUD() {
         for (final Locale locale : Locale.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.setCurrencyAndCheck(locale,
@@ -268,7 +268,7 @@ public final class DecimalFormatSymbolsTest implements ClassTesting<DecimalForma
     @Test
     public void testSetCurrencyAllLocalesAllCurrencies() {
         for (final Locale locale : Locale.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             for (final Currency currency : Currency.getAvailableCurrencies()) {
@@ -299,7 +299,7 @@ public final class DecimalFormatSymbolsTest implements ClassTesting<DecimalForma
     @Test
     public void testSetCurrencySymbolAllLocalesAUD() {
         for (final Locale locale : Locale.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.setCurrencySymbolAndCheck(locale, "AUD");
@@ -309,7 +309,7 @@ public final class DecimalFormatSymbolsTest implements ClassTesting<DecimalForma
     @Test
     public void testSetCurrencySymbolAllLocalesAllCurrencySymbols() {
         for (final Locale locale : Locale.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
 

--- a/src/test/java/walkingkooka/j2cl/java/text/DecimalFormatTest.java
+++ b/src/test/java/walkingkooka/j2cl/java/text/DecimalFormatTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.HashCodeEqualsDefinedTesting2;
 import walkingkooka.InvalidCharacterException;
 import walkingkooka.ToStringTesting;
-import walkingkooka.javautillocalej2cl.WalkingkookaLocale;
+import walkingkooka.j2cl.WalkingkookaLanguageTag;
 import walkingkooka.text.CharSequences;
 
 import java.math.RoundingMode;
@@ -87,7 +87,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testCurrencyInstanceDefaultAllLocales() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.currencyInstanceAndCheck(locale);
@@ -105,7 +105,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testCurrencyInstanceCloned() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
 
@@ -136,7 +136,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testCurrencyInstanceLocaleDefaultAllLocales() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.currencyInstanceLocaleAndCheck(locale);
@@ -152,7 +152,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testCurrencyInstanceLocaleCloned() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
 
@@ -181,7 +181,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testIntegerInstanceDefaultAllLocales() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.integerInstanceAndCheck(locale);
@@ -199,7 +199,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testIntegerInstanceCloned() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
 
@@ -230,7 +230,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testIntegerInstanceLocaleDefaultAllLocales() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.integerInstanceLocaleAndCheck(locale);
@@ -246,7 +246,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testIntegerInstanceLocaleCloned() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
 
@@ -275,7 +275,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testInstanceDefaultAllLocales() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.instanceAndCheck(locale);
@@ -293,7 +293,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testInstanceCloned() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
 
@@ -324,7 +324,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testInstanceLocaleDefaultAllLocales() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.instanceLocaleAndCheck(locale);
@@ -340,7 +340,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testInstanceLocaleCloned() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
 
@@ -369,7 +369,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testNumberInstanceDefaultAllLocales() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.numberInstanceAndCheck(locale);
@@ -387,7 +387,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testNumberInstanceCloned() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
 
@@ -418,7 +418,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testNumberInstanceLocaleDefaultAllLocales() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.numberInstanceLocaleAndCheck(locale);
@@ -434,7 +434,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testNumberInstanceLocaleCloned() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
 
@@ -463,7 +463,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testPercentInstanceDefaultAllLocales() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.percentInstanceAndCheck(locale);
@@ -481,7 +481,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testPercentInstanceCloned() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
 
@@ -512,7 +512,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testPercentInstanceLocaleDefaultAllLocales() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.percentInstanceLocaleAndCheck(locale);
@@ -528,7 +528,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testPercentInstanceLocaleCloned() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
 
@@ -557,7 +557,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testNewDefaultAllLocales() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
             this.newAndCheck(locale);
@@ -705,7 +705,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testNewPatternAllLocales() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
 
@@ -747,7 +747,7 @@ public final class DecimalFormatTest extends FormatTestCase<DecimalFormat> imple
     @Test
     public void testNewPatternSymbolsAllLocales() {
         for (final Locale locale : java.text.DecimalFormat.getAvailableLocales()) {
-            if (WalkingkookaLocale.isUnsupported(locale.toLanguageTag())) {
+            if (WalkingkookaLanguageTag.isUnsupported(locale.toLanguageTag())) {
                 continue;
             }
 

--- a/src/test/java/walkingkooka/j2cl/java/text/LocaleProviderTool.java
+++ b/src/test/java/walkingkooka/j2cl/java/text/LocaleProviderTool.java
@@ -17,7 +17,7 @@
 
 package walkingkooka.j2cl.java.text;
 
-import walkingkooka.javautillocalej2cl.WalkingkookaLanguageTagTool;
+import walkingkooka.j2cl.WalkingkookaLanguageTagTool;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.printer.IndentingPrinter;
 


### PR DESCRIPTION
- Swapped dependency to j2cl-java-util-Locale was java-util-Locale-j2cl (old name)
- https://github.com/mP1/j2cl-java-util-Locale/pull/55
- WalkingkookaLocale.isUnsupported taken from WalkingkookaLocale