### PR TITLE
j2cl-java-util-currency-annotation-processor c86c0facf9bcbbc13bf08ae1…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ To match compatibility the behaviour of ignoring the counts are ignored.
 
 
 
+## Currency
+
+The currency code `XXX` must be selected as it is used by various `java.text` classes as a source of defaults.
+
+
+
 
 ## Missing functionality
 

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
                     <target>9</target>
                     <compilerArgs>
                         <arg>-Awalkingkooka.j2cl.java.util.Locale=*</arg>
+                        <arg>-Awalkingkooka.j2cl.java.util.Currency=XXX</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/src/it/dateformatsymbols-junit-test/pom.xml
+++ b/src/it/dateformatsymbols-junit-test/pom.xml
@@ -200,6 +200,7 @@
                             </formatting>
                             <java-compiler-arguments>
                                 <param>-Awalkingkooka.j2cl.java.util.Locale=EN*</param>
+                                <param>-Awalkingkooka.j2cl.java.util.Currency=XXX</param>
                             </java-compiler-arguments>
                             <language-out>ECMASCRIPT_2016</language-out>
                             <!-- dont want to parallelize -->

--- a/src/it/decimalformat-junit-test/pom.xml
+++ b/src/it/decimalformat-junit-test/pom.xml
@@ -207,6 +207,7 @@
                             </formatting>
                             <java-compiler-arguments>
                                 <param>-Awalkingkooka.j2cl.java.util.Locale=und,EN*,FR*</param>
+                                <param>-Awalkingkooka.j2cl.java.util.Currency=XXX</param>
                             </java-compiler-arguments>
                             <language-out>ECMASCRIPT_2016</language-out>
                             <!-- dont want to parallelize -->

--- a/src/it/decimalformatsymbols-junit-test/pom.xml
+++ b/src/it/decimalformatsymbols-junit-test/pom.xml
@@ -201,6 +201,7 @@
                             </formatting>
                             <java-compiler-arguments>
                                 <param>-Awalkingkooka.j2cl.java.util.Locale=EN*,FR*</param>
+                                <param>-Awalkingkooka.j2cl.java.util.Currency=XXX</param>
                             </java-compiler-arguments>
                             <language-out>ECMASCRIPT_2016</language-out>
                             <!-- dont want to parallelize -->


### PR DESCRIPTION
…d39a2457332fe699 20200511

- https://github.com/mP1/j2cl-java-util-currency-annotation-processor/pull/24
- Currency-code annotation processor argument

- Updated POMs with new required annotation processor currency argument.