### PR TITLE
j2cl-java-util-TimeZone 33c2e5364c036750f00a3d7d23ecc62cab9ccc3b 2020…

### DIFF
--- a/src/it/dateformats-junit-test/pom.xml
+++ b/src/it/dateformats-junit-test/pom.xml
@@ -193,6 +193,8 @@
                                 <jre.checkedMode>DISABLED</jre.checkedMode>
                                 <jre.checks.checkLevel>MINIMAL</jre.checks.checkLevel>
                                 <jsinterop.checks>DISABLED</jsinterop.checks>
+                                <walkingkooka.j2cl.java.util.locale.Locale.DEFAULT>EN-AU</walkingkooka.j2cl.java.util.locale.Locale.DEFAULT>
+                                <walkingkooka.j2cl.java.util.timezone.TimeZone.DEFAULT>Australia/Sydney</walkingkooka.j2cl.java.util.timezone.TimeZone.DEFAULT>
                             </defines>
                             <externs/>
                             <formatting>

--- a/src/it/dateformatsymbols-junit-test/pom.xml
+++ b/src/it/dateformatsymbols-junit-test/pom.xml
@@ -193,6 +193,8 @@
                                 <jre.checkedMode>DISABLED</jre.checkedMode>
                                 <jre.checks.checkLevel>MINIMAL</jre.checks.checkLevel>
                                 <jsinterop.checks>DISABLED</jsinterop.checks>
+                                <walkingkooka.j2cl.java.util.locale.Locale.DEFAULT>EN-AU</walkingkooka.j2cl.java.util.locale.Locale.DEFAULT>
+                                <walkingkooka.j2cl.java.util.timezone.TimeZone.DEFAULT>Australia/Sydney</walkingkooka.j2cl.java.util.timezone.TimeZone.DEFAULT>
                             </defines>
                             <externs/>
                             <formatting>

--- a/src/it/decimalformat-junit-test/pom.xml
+++ b/src/it/decimalformat-junit-test/pom.xml
@@ -199,7 +199,8 @@
                                 <jre.checkedMode>DISABLED</jre.checkedMode>
                                 <jre.checks.checkLevel>MINIMAL</jre.checks.checkLevel>
                                 <jsinterop.checks>DISABLED</jsinterop.checks>
-                                <walkingkooka-java-util-Locale-default>EN-*,FR-*</walkingkooka-java-util-Locale-default>
+                                <walkingkooka.j2cl.java.util.locale.Locale.DEFAULT>EN-AU</walkingkooka.j2cl.java.util.locale.Locale.DEFAULT>
+                                <walkingkooka.j2cl.java.util.timezone.TimeZone.DEFAULT>Australia/Sydney</walkingkooka.j2cl.java.util.timezone.TimeZone.DEFAULT>
                             </defines>
                             <externs/>
                             <formatting>

--- a/src/it/decimalformatsymbols-junit-test/pom.xml
+++ b/src/it/decimalformatsymbols-junit-test/pom.xml
@@ -194,6 +194,8 @@
                                 <jre.checkedMode>DISABLED</jre.checkedMode>
                                 <jre.checks.checkLevel>MINIMAL</jre.checks.checkLevel>
                                 <jsinterop.checks>DISABLED</jsinterop.checks>
+                                <walkingkooka.j2cl.java.util.locale.Locale.DEFAULT>EN-AU</walkingkooka.j2cl.java.util.locale.Locale.DEFAULT>
+                                <walkingkooka.j2cl.java.util.timezone.TimeZone.DEFAULT>Australia/Sydney</walkingkooka.j2cl.java.util.timezone.TimeZone.DEFAULT>
                             </defines>
                             <externs/>
                             <formatting>


### PR DESCRIPTION
…0614

- https://github.com/mP1/j2cl-java-util-TimeZone/pull/80
- Default TimeZone system property

- https://github.com/mP1/j2cl-java-util-Locale/pull/129
- default Locale system property